### PR TITLE
docs: add a kube cmd to delete all pods in failed/evicted status

### DIFF
--- a/Kubernetes/commands/README.md
+++ b/Kubernetes/commands/README.md
@@ -106,6 +106,12 @@ kubectl delete deployment <deployment-name>
 kubectl delete pod <pod-name>
 ```
 
+- To delete evicted pods
+
+```bash
+kubectl delete pod --field-selector="status.phase==Failed"
+```
+
 - To get logs of a pod
 
 ```bash


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

<!-- Example: Closes #31 -->

## 👨‍💻 Changes proposed

<!-- List all the proposed changes in your PR -->

Added a Kubernetes command to delete `evicted` and `failed` pods!
> Sometimes, pods are evicted according to the resource, like memory or disk space, causing the node pressure

### Eviction in Kubernetes: Understanding the Process

As Kubernetes continues to grow in popularity, it's important to have a clear understanding of how it handles resource management. One aspect of this is the eviction process, which occurs when a Pod assigned to a Node needs to be terminated.

###  What is Eviction in Kubernetes ?

Eviction is a process that occurs when a Pod assigned to a Node is asked to terminate. There are several reasons why this might happen, but the most common is preemption. Preemption occurs when Kubernetes needs to schedule a new Pod on a Node that has limited resources. In order to free up resources for the new Pod, another Pod needs to be terminated.

Other reasons why a Pod might be evicted include Node maintenance, resource usage violations, and Pod lifecycle events such as Job or DaemonSet completion. Regardless of the reason, eviction is a necessary aspect of resource management in Kubernetes.

###  Understanding Preemption in Kubernetes

Preemption is the most common reason for eviction in Kubernetes.

In Kubernetes, each Node has a set of resources, including `CPU` and `memory`, that can be allocated to Pods. When a new Pod is scheduled on a Node, Kubernetes needs to ensure that there are enough resources available to meet the Pod's requirements. If there are not enough resources, Kubernetes will try to free up resources by evicting one or more existing Pods.

When a Pod is selected for eviction, Kubernetes will follow a set of rules to determine which Pod to terminate. These rules are based on the Pod's priority and the resources it's using. Pods with lower priority and higher resource usage are more likely to be selected for eviction.

Once a Pod has been selected for eviction, Kubernetes will send a termination signal to the Pod's containers. The containers will then have a configurable amount of time to shut down gracefully before they are forcefully terminated. Kubernetes will also mark the Node as unschedulable during this time to prevent new Pods from being scheduled on it.

I was managing a cluster where my pods keep being evicted due to wrong configurations, and once a pod is evicted, it's kept in the node list when you use `kubectl get pods`. So I find this command helpful to clean my Node if it's happening. :)

### What is Field Selectors on Kubernetes?

From [`K8S documentation`](https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/):
> Field selectors let you [select Kubernetes resources](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects) based on the value of one or more resource fields.

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## 📄 Note to reviewers

<!-- Add notes to reviewers if applicable -->

## 📷 Screenshots

<a href="https://gitpod.io/#https://github.com/Pradumnasaraf/DevOps/pull/43"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

