### PR TITLE
fix: Typo's in Kubernetes/README.md

### DIFF
--- a/Bash-Scripting/README.md
+++ b/Bash-Scripting/README.md
@@ -131,7 +131,7 @@ if [$1 == "hello"],then echo "Hello World", fi
 
 ### Loops
 
-We can use loops to repeat a set of commands. There are two types of loops in bash. `for` and `while`. The the body is enclosed in `do` and `done`.
+We can use loops to repeat a set of commands. There are two types of loops in bash. `for` and `while`. The body is enclosed in `do` and `done`.
 
 #### For Loop
 

--- a/Kubernetes/README.md
+++ b/Kubernetes/README.md
@@ -136,7 +136,7 @@ Services are for internal communication of pods. It also helps give a pop static
 
 - **ClusterIP**: For inter communication of pods  
 
-- **HeadLess**: It is a direct communication with a pod. No load blancing is required. So in this ClusterIp is none
+- **HeadLess**: It is a direct communication with a pod. No load balancing is required. So in this ClusterIp is none
 
 ```yaml
 spec:
@@ -209,7 +209,7 @@ kubectl port-forward <pod-name> <localhost-port>
 
 ### Ingress
 
-It is use for an external trafic/request, which can be accessed by an URL instaed of `IP-PORT - 17.28.55.44.5:7800`. For that we need an ingress controller to make work of ingress.
+It is use for an external trafic/request, which can be accessed by an URL instead of `IP-PORT - 17.28.55.44.5:7800`. For that we need an ingress controller to make work of ingress.
 
 ![Ingress](https://user-images.githubusercontent.com/51878265/201585224-eca055af-eeb6-473c-bd96-33af9b5f6c55.png)
 
@@ -340,7 +340,7 @@ data:
 
 First we create the Persistent Volume(PV) and then we claim it by creating Persistent Volume Claim (PVC). Then that claim is mounted to the pod. But when we use cloud provides we can claim the storage directly from the cloud provider.
 
-- Note: Persistent volume is indepent of the namespace, but Persistent Volume Claim is bound to a specfic.
+- Note: Persistent volume is independent of the namespace, but Persistent Volume Claim is bound to a specfic.
 
 ## Cluster Config file
 
@@ -352,7 +352,7 @@ All the Cluster info is stored in the file name `config` with the path:
 
 ## Networking
 
-Container communication - The container inside a pod communicate via localhost shares the same networking namespace. To test it out, `Curl` the other conatiner by exec into the 1st container.
+Container communication - The container inside a pod communicate via localhost shares the same networking namespace. To test it out, `Curl` the other container by exec into the 1st container.
 
 Steps
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->
Close #68 

## 👨‍💻 Changes proposed

<!-- List all the proposed changes in your PR -->
I have addressed the spelling errors by making the following corrections:

1. Replaced "blancing" with "balancing."
2. Replaced "instaed" with "instead."
3. Replaced "indepent" with "independent."
4. Replaced "conatiner" with "container."

Please note that the first two corrections were not initially reported as part of the issue, but I have made the changes nonetheless. I hope this clarifies the matter. Thanks.
## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## 📄 Note to reviewers

<!-- Add notes to reviewers if applicable -->

## 📷 Screenshots

<a href="https://gitpod.io/#https://github.com/Pradumnasaraf/DevOps/pull/69"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

