### PR TITLE
Override qs and nanoid to clear 3 Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13047,9 +13047,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -15317,9 +15317,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "@docusaurus/types": "^3.9.2"
   },
   "overrides": {
-    "serialize-javascript": "7.0.5"
+    "serialize-javascript": "7.0.5",
+    "nanoid": "3.3.18",
+    "qs": "6.16.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## What this fixes

Closes 3 of the 6 remaining open Dependabot alerts. All 6 are transitive dependencies of `@docusaurus/*`, so none of them can be fixed by bumping a direct dependency. This repo already uses npm `overrides` for exactly this (`serialize-javascript`), so this follows that pattern.

| Alert | Package | Was | Now | Result |
|---|---|---|---|---|
| #143, #144 (medium) | `qs` | 6.15.3 | **6.16.0** | fixed |
| #138 (high) | `nanoid` | 3.3.16 | **3.3.18** | fixed |
| #128 (medium) | `uuid` | 8.3.2 | unchanged | left alone, see below |
| #134, #135 (high) | `image-size` | 2.0.2 | unchanged | no upstream fix exists |

Both overrides are same-major patch/minor bumps, so no API surface changes.

## Why `uuid` is left alone

`uuid` comes in via `sockjs` <- `webpack-dev-server` <- `@docusaurus/core`. Two things matter here:

1. The advisory wants `>= 11.1.1` and the tree is on `8.3.2`. That is three majors, and `sockjs` calls the v8 API. Forcing it is a good way to break `npm start` for a moderate-severity advisory.
2. `webpack-dev-server` only runs for local `docusaurus start`. It is not in the production build and not in the deployed static site, so the actual exposure is a local dev server.

My suggestion is to leave it until `sockjs` or `webpack-dev-server` update, or dismiss the alert as dev-only. Happy to force the override instead if you would rather see the alert count at zero, but it should be a deliberate call.

## Why `image-size` is left alone

`first_patched_version` on both alerts is `null`. There is no fixed version published, so there is nothing to override to. It arrives through `@docusaurus/mdx-loader`, so it clears when Docusaurus updates its own pin. Nothing actionable here right now.

## Verification

- `npm install` resolves `qs@6.16.0` and `nanoid@3.3.18`, confirmed with `npm ls`
- `npm run build` succeeds, client and server both compile, static files generated

Note that `npm audit` will still report findings after this. Its counts do not line up with Dependabot's, and most of what remains is the dev-only `webpack-dev-server` chain described above.
